### PR TITLE
Added APIs to specify external JSONParser as source

### DIFF
--- a/justify/src/main/java/org/leadpony/justify/api/JsonSchemaReaderFactory.java
+++ b/justify/src/main/java/org/leadpony/justify/api/JsonSchemaReaderFactory.java
@@ -21,6 +21,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Path;
 
 import javax.json.JsonException;
+import javax.json.stream.JsonParser;
 
 /**
  * A factory interface for creating {@link JsonSchemaReader} instances.
@@ -97,4 +98,13 @@ public interface JsonSchemaReaderFactory {
      * @see JsonSchemaReader
      */
     JsonSchemaReader createSchemaReader(Path path);
+
+    /**
+     * Creates a JSON schema reader from a specific parser.
+     *
+     * @param parser the parser to use to read the schema.
+     * @throws NullPointerException if the specified {@code in} is {@code null}.
+     * @see JsonSchemaReader
+     */
+    JsonSchemaReader createSchemaReader(JsonParser parser);
 }

--- a/justify/src/main/java/org/leadpony/justify/api/JsonValidationService.java
+++ b/justify/src/main/java/org/leadpony/justify/api/JsonValidationService.java
@@ -176,6 +176,22 @@ public interface JsonValidationService extends JsonSchemaReaderFactory {
     }
 
     /**
+     * Reads a JSON schema from a specified non-validating parser.
+     *
+     * @param parser the parser to reader from
+     * @return the read JSON schema.
+     * @throws NullPointerException    if the specified {@code parser} is
+     *                                 {@code null}.
+     * @throws JsonValidatingException if the reader found problems during
+     *                                 validation of the schema.
+     */
+    default JsonSchema readSchema(JsonParser parser) {
+        try (JsonSchemaReader schemaReader = createSchemaReader(parser)) {
+            return schemaReader.read();
+        }
+    }
+
+    /**
      * Creates a factory for creating JSON schema builders.
      *
      * @return the newly created instance of JSON schema builder factory.
@@ -302,6 +318,22 @@ public interface JsonValidationService extends JsonSchemaReaderFactory {
     JsonParser createParser(Path path, JsonSchema schema, ProblemHandler handler);
 
     /**
+     * Creates a JSON parser from the specified not validating parser, which validates
+     * the JSON document while parsing.
+     *
+     * @param parser  the parser from which JSON is to be read.
+     * @param schema  the JSON schema to apply when validating JSON document.
+     * @param handler the object which handles problems found during the validation,
+     *                cannot be {@code null}.
+     * @return newly created instance of {@code JsonParser}, which is defined in the
+     *         JSON Processing API. It must be closed by the method caller after
+     *         use.
+     * @throws JsonException        if an I/O error occurs while creating parser.
+     * @throws NullPointerException if any of specified parameters is {@code null}.
+     */
+    JsonParser createParser(JsonParser parser, JsonSchema schema, ProblemHandler handler);
+
+    /**
      * Creates a reader factory for creating {@code JsonReader} instances. Readers
      * created by the factory can validate JSON documents while reading.
      * <p>
@@ -402,6 +434,22 @@ public interface JsonValidationService extends JsonSchemaReaderFactory {
      * @throws NullPointerException if any of specified parameters is {@code null}.
      */
     JsonReader createReader(Path path, JsonSchema schema, ProblemHandler handler);
+
+    /**
+     * Creates a JSON reader from a non-validating JSON parser, which validates the
+     * JSON document while reading.
+     *
+     * @param parser  the parser from which JSON is to be read.
+     * @param schema  the JSON schema to apply when validating JSON document.
+     * @param handler the object which handles problems found during the validation,
+     *                cannot be {@code null}.
+     * @return newly created instance of {@code JsonReader}, which is defined in the
+     *         JSON Processing API. It must be closed by the method caller after
+     *         use.
+     * @throws JsonException        if an I/O error occurs while creating reader.
+     * @throws NullPointerException if any of specified parameters is {@code null}.
+     */
+    JsonReader createReader(JsonParser parser, JsonSchema schema, ProblemHandler handler);
 
     /**
      * Creates a JSON provider for validating JSON documents while parsing and

--- a/justify/src/main/java/org/leadpony/justify/internal/provider/DefaultJsonValidationService.java
+++ b/justify/src/main/java/org/leadpony/justify/internal/provider/DefaultJsonValidationService.java
@@ -138,6 +138,14 @@ class DefaultJsonValidationService extends JsonService implements JsonValidation
      * {@inheritDoc}
      */
     @Override
+    public JsonSchemaReader createSchemaReader(JsonParser parser) {
+        return createSchemaReaderFactory().createSchemaReader(parser);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public JsonSchemaBuilderFactory createSchemaBuilderFactory() {
         return createDefaultSchemaBuilderFactory();
     }
@@ -240,6 +248,17 @@ class DefaultJsonValidationService extends JsonService implements JsonValidation
      * {@inheritDoc}
      */
     @Override
+    public JsonParser createParser(JsonParser parser, JsonSchema schema, ProblemHandler handler) {
+        requireNonNull(parser, "parser");
+        requireNonNull(schema, "schema");
+        requireNonNull(handler, "handler");
+        return createValidator(parser, schema, handler);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public JsonReaderFactory createReaderFactory(Map<String, ?> config) {
         if (config == null) {
             config = Collections.emptyMap();
@@ -301,6 +320,15 @@ class DefaultJsonValidationService extends JsonService implements JsonValidation
     @Override
     public JsonReader createReader(Path path, JsonSchema schema, ProblemHandler handler) {
         JsonParser parser = createParser(path, schema, handler);
+        return createReader(parser);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public JsonReader createReader(JsonParser parser, JsonSchema schema, ProblemHandler handler) {
+        JsonParser validatingParser = createParser(parser, schema, handler);
         return createReader(parser);
     }
 

--- a/justify/src/main/java/org/leadpony/justify/internal/schema/io/JsonSchemaReaderFactoryImpl.java
+++ b/justify/src/main/java/org/leadpony/justify/internal/schema/io/JsonSchemaReaderFactoryImpl.java
@@ -118,6 +118,13 @@ public class JsonSchemaReaderFactoryImpl implements JsonSchemaReaderFactory {
         }
     }
 
+    @Override
+    public JsonSchemaReader createSchemaReader(JsonParser parser) {
+        requireNonNull(parser, "parser");
+        SchemaSpec spec = getSpec(defaultVersion);
+        return createSpecificSchemaReader(parser, spec);
+    }
+
     /**
      * Returns the instance of {@link SchemaSpec} for the specified version.
      *


### PR DESCRIPTION
Hi,

First thank you for this lovely library.

My own business case requires the validation of JSON that already exists. For example, verifying that a JSON structure still conforms to the schema after applying a patch, or where the schema is not known at the time of the initial parse.

Whilst I understand you are considering adapting this library to work in a non-streaming mode, it occurred to me that being able to specify a JsonParser instance wherever the API offered a choice of Reader or InputStream would allow a solution that was at least more efficient that converting the existing JSON structure back to text and then re-reading it.

Please would you consider incorporating these changes into your library.

Kind Regards,

Dr Simon Greatrix